### PR TITLE
fix(core): Infer tool `invoke` return type from provided function

### DIFF
--- a/langchain-core/src/tools/index.ts
+++ b/langchain-core/src/tools/index.ts
@@ -69,7 +69,7 @@ export abstract class StructuredTool<
   ToolOutputT = ToolReturnType
 > extends BaseLangChain<
   StructuredToolCallInput<SchemaT, SchemaInputT>,
-  ToolOutputT
+  ToolOutputT | ToolMessage
 > {
   abstract name: string;
 
@@ -122,10 +122,10 @@ export abstract class StructuredTool<
    * @param config Optional configuration for the tool.
    * @returns A Promise that resolves with a string.
    */
-  async invoke(
-    input: StructuredToolCallInput<SchemaT, SchemaInputT>,
+  async invoke<TInput extends StructuredToolCallInput<SchemaT, SchemaInputT>>(
+    input: TInput,
     config?: RunnableConfig
-  ): Promise<ToolOutputT> {
+  ): Promise<TInput extends ToolCall ? ToolMessage : ToolOutputT> {
     let tool_call_id: string | undefined;
     let toolInput: Exclude<
       StructuredToolCallInput<SchemaT, SchemaInputT>,
@@ -154,7 +154,9 @@ export abstract class StructuredTool<
       >;
     }
 
-    return this.call(toolInput, enrichedConfig);
+    return this.call(toolInput, enrichedConfig) as Promise<
+      TInput extends ToolCall ? ToolMessage : ToolOutputT
+    >;
   }
 
   /**
@@ -173,7 +175,7 @@ export abstract class StructuredTool<
     configArg?: Callbacks | ToolRunnableConfig,
     /** @deprecated */
     tags?: string[]
-  ): Promise<ToolOutputT> {
+  ): Promise<ToolMessage | ToolOutputT> {
     let parsed = arg;
     if (isZodSchema(this.schema)) {
       try {
@@ -286,7 +288,7 @@ export abstract class Tool<ToolOutputT = ToolReturnType> extends StructuredTool<
   call(
     arg: string | undefined | z.input<this["schema"]> | ToolCall,
     callbacks?: Callbacks | RunnableConfig
-  ): Promise<ToolOutputT> {
+  ): Promise<ToolMessage | ToolOutputT> {
     return super.call(
       typeof arg === "string" || !arg ? { input: arg } : arg,
       callbacks
@@ -324,7 +326,7 @@ export class DynamicTool<
   async call(
     arg: string | undefined | z.input<this["schema"]> | ToolCall,
     configArg?: ToolRunnableConfig | Callbacks
-  ): Promise<ToolOutputT> {
+  ): Promise<ToolMessage | ToolOutputT> {
     const config = parseCallbackConfigArg(configArg);
     if (config.runName === undefined) {
       config.runName = this.name;
@@ -388,7 +390,7 @@ export class DynamicStructuredTool<
     configArg?: RunnableConfig | Callbacks,
     /** @deprecated */
     tags?: string[]
-  ): Promise<ToolOutputT> {
+  ): Promise<ToolMessage | ToolOutputT> {
     const config = parseCallbackConfigArg(configArg);
     if (config.runName === undefined) {
       config.runName = this.name;
@@ -626,12 +628,12 @@ export function tool<
           >;
 }
 
-function _formatToolOutput(params: {
-  content: unknown;
+function _formatToolOutput<TOutput extends ToolReturnType>(params: {
+  content: TOutput;
   name: string;
   artifact?: unknown;
   toolCallId?: string;
-}): ToolReturnType {
+}): ToolMessage | TOutput {
   const { content, artifact, toolCallId } = params;
   if (toolCallId && !isDirectToolOutput(content)) {
     if (

--- a/langchain-core/src/tools/types.ts
+++ b/langchain-core/src/tools/types.ts
@@ -13,7 +13,7 @@ import {
   RunnableToolLike,
   type RunnableInterface,
 } from "../runnables/base.js";
-import type { ToolCall } from "../messages/tool.js";
+import type { ToolCall, ToolMessage } from "../messages/tool.js";
 import type { MessageContent } from "../messages/base.js";
 import { isZodSchema } from "../utils/types/is_zod_schema.js";
 import { JSONSchema } from "../utils/json_schema.js";
@@ -183,12 +183,12 @@ export interface StructuredToolInterface<
    * @param tags Optional tags for the tool.
    * @returns A Promise that resolves with a string.
    */
-  call(
-    arg: StructuredToolCallInput<SchemaT, SchemaInputT>,
+  call<TArg extends StructuredToolCallInput<SchemaT, SchemaInputT>>(
+    arg: TArg,
     configArg?: Callbacks | RunnableConfig,
     /** @deprecated */
     tags?: string[]
-  ): Promise<ToolOutputT>;
+  ): Promise<TArg extends ToolCall ? ToolMessage : ToolOutputT>;
 
   /**
    * The name of the tool.
@@ -232,11 +232,11 @@ export interface ToolInterface<
    * @param callbacks Optional callbacks for the tool.
    * @returns A Promise that resolves with a string.
    */
-  call(
+  call<TArg extends string | undefined | SchemaInputT | ToolCall>(
     // TODO: shouldn't this be narrowed based on SchemaT?
-    arg: string | undefined | SchemaInputT | ToolCall,
+    arg: TArg,
     callbacks?: Callbacks | RunnableConfig
-  ): Promise<ToolOutputT>;
+  ): Promise<TArg extends ToolCall ? ToolMessage : ToolOutputT>;
 }
 
 /**


### PR DESCRIPTION
Fixes #8010. Instead of just using an `any` alias as the return type to invoke, this adds a generic `ToolOutputT` type param on the tool classes that decides the return type of invoke. 

A later enhancement could be to restrict the return type of the provided function if "content_and_artifact" is provided as the response format (i.e. instead of `any[]`, the return type is forced to be `extends [any, any]` in the tool function)